### PR TITLE
Fix: Handle null payload - return 422 instead of 500

### DIFF
--- a/src/Http/Response/ResponseBuilder.php
+++ b/src/Http/Response/ResponseBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AppHttpResponse;
+
+class ResponseBuilder
+{
+    /**
+     * Handle null payload gracefully
+     * Returns 422 with validation error instead of 500
+     */
+    public function build( = null, int  = 200): array
+    {
+        if ( === null &&  === 200) {
+            return [
+                'success' => false,
+                'code' => 422,
+                'message' => 'Payload cannot be null',
+                'data' => null
+            ];
+        }
+
+        return [
+            'success' =>  >= 200 &&  < 300,
+            'code' => ,
+            'message' => 'OK',
+            'data' =>         ];
+    }
+}


### PR DESCRIPTION
Fixes #10

When a null payload is sent, the response builder now returns a 422 error instead of throwing a 500.